### PR TITLE
Fix getVersion colon handling

### DIFF
--- a/www/js/analytic.js
+++ b/www/js/analytic.js
@@ -81,10 +81,10 @@
 
     function getVersion() {
         var versionStringSplit = $('#version').html().split(':');
-        if( versionStringSplit.length >= 1) {
-            return '0.0.0'
-        } else {
+        if (versionStringSplit.length > 1) {
             return versionStringSplit[1].trim().split('<')[0];
+        } else {
+            return '0.0.0';
         }
     };
 })();


### PR DESCRIPTION
## Summary
- fix detection logic in `www/js/analytic.js`
- ensure default version return statement has semicolon

## Testing
- `npm test` *(fails: `jasmine-node` not found)*